### PR TITLE
feat: Multi Window Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ It is also possible to configure these values through `appsettings.json` like so
 }
 ```
 > [!NOTE]
-> The `Window` object itself is also made available inside of the DI container by injecting `BlazorDesktopWindow`, so you can access all properties on it by using the inject Razor keyword or requesting it through the constructor of a class added as a service.
-> The `BlazorDesktopWindow` inherits from the WPF `Window` class, as such you use WPF apis to manipulate it. WPF documentation for the Window class can be found [here](https://learn.microsoft.com/en-us/dotnet/api/system.windows.window?view=windowsdesktop-9.0).
+> The main window can be accessed through the `IWindowManager` service available in the DI container. Use `IWindowManager.MainWindow` to get a handle to it.
+> The underlying `BlazorDesktopWindow` inherits from the WPF `Window` class, as such you use WPF apis to manipulate it. WPF documentation for the Window class can be found [here](https://learn.microsoft.com/en-us/dotnet/api/system.windows.window?view=windowsdesktop-9.0).
 > Examples of usage can be found below.
 
 ## Custom Window Chrome & Draggable Regions
@@ -153,14 +153,14 @@ Using the base template, if you were to edit `MainLayout.razor` and add a `-webk
 ```
 The top bar becomes draggable, applying the `-webkit-app-region: drag;` property to anything will make it able to be used to drag the window.
 
-In terms of handling things such as the close button, you can inject the Window into any page and interact from it there.
+In terms of handling things such as the close button, you can inject `IWindowManager` into any page and interact with the main window from there.
 
 Here is an example changing `MainLayout.razor`:
 ```razor
-@using BlazorDesktop.Wpf
+@using BlazorDesktop.Services
 
 @inherits LayoutComponentBase
-@inject BlazorDesktopWindow window
+@inject IWindowManager WindowManager
 
 <div class="page">
     <div class="sidebar">
@@ -181,7 +181,7 @@ Here is an example changing `MainLayout.razor`:
 @code {
     void CloseWindow()
     {
-        window.Close();
+        WindowManager.MainWindow.NativeWindow?.Close();
     }
 }
 ```
@@ -190,23 +190,128 @@ To support fullscreen mode, you should also hide your custom window chrome when 
 ## Changing Window Properties During Startup
 It is possible to customize window startup behaviors for Blazor Desktop apps. As an example base setup you could do the following:
 
-Using the base template, if you were to edit `MainLayout.razor` and inject the `BlazorDesktopWindow` you can have the window be maximized on launch using Blazor's `OnInitialized` lifecycle method:
+Using the base template, if you were to edit `MainLayout.razor` and inject `IWindowManager` you can have the window be maximized on launch using Blazor's `OnInitialized` lifecycle method:
 ```razor
-@using BlazorDesktop.Wpf
+@using BlazorDesktop.Services
 @using System.Windows
 @inherits LayoutComponentBase
 
-@inject BlazorDesktopWindow window
+@inject IWindowManager WindowManager
 
 ...
 
 @code {
     protected override void OnInitialized()
     {
-        window.WindowState = WindowState.Maximized;
+        if (WindowManager.MainWindow.NativeWindow is { } window)
+        {
+            window.WindowState = WindowState.Maximized;
+        }
     }
 }
 ```
+
+## Multi-Window Support
+Blazor Desktop supports opening multiple windows, each with its own independent Blazor component tree. There are two ways to create child windows: a **service-based API** for programmatic control and a **component-based API** for declarative Razor usage.
+
+### Service-based API
+Inject `IWindowManager` and call `OpenAsync` to open a new window programmatically:
+
+```razor
+@using BlazorDesktop.Services
+@inject IWindowManager WindowManager
+
+<button @onclick="OpenSettings">Open Settings</button>
+
+@code {
+    private async Task OpenSettings()
+    {
+        var handle = await WindowManager.OpenAsync<SettingsPanel>(options =>
+        {
+            options.Title = "Settings";
+            options.Width = 600;
+            options.Height = 400;
+        });
+
+        // React when the window is closed (user clicks X or closed programmatically)
+        handle.Closed += (sender, args) =>
+        {
+            // Handle cleanup
+        };
+    }
+}
+```
+
+You can also close a window programmatically:
+```csharp
+await WindowManager.CloseAsync(handle);
+```
+
+### Component-based API
+Use the `<DesktopWindow>` component to open and close windows declaratively. The window opens when the component is rendered and closes when it is removed from the render tree:
+
+```razor
+@using BlazorDesktop.Components
+
+<button @onclick="() => showSettings = !showSettings">Toggle Settings</button>
+
+@if (showSettings)
+{
+    <DesktopWindow ComponentType="typeof(SettingsPanel)"
+                   Title="Settings" Width="600" Height="400"
+                   OnClosed="@(() => { showSettings = false; InvokeAsync(StateHasChanged); })" />
+}
+
+@code {
+    private bool showSettings = false;
+}
+```
+
+The `OnClosed` callback fires when the user closes the window (e.g. clicks the X button), allowing you to keep your state in sync.
+
+### Window Options
+Both APIs accept the same set of window options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `Title` | `string?` | App name | Window title |
+| `Width` | `int?` | `1366` | Window width in pixels |
+| `Height` | `int?` | `768` | Window height in pixels |
+| `MinWidth` | `int?` | `0` | Minimum width |
+| `MinHeight` | `int?` | `0` | Minimum height |
+| `MaxWidth` | `int?` | unlimited | Maximum width |
+| `MaxHeight` | `int?` | unlimited | Maximum height |
+| `Frame` | `bool?` | `true` | Use standard window frame |
+| `Resizable` | `bool?` | `true` | Allow resizing |
+| `Icon` | `string?` | `favicon.ico` | Icon path (relative to `wwwroot`) |
+
+### IWindowManager Reference
+The `IWindowManager` service is available in the DI container and provides:
+
+| Member | Description |
+|--------|-------------|
+| `MainWindow` | Handle to the main application window |
+| `Windows` | List of all currently open window handles |
+| `OpenAsync<TComponent>(...)` | Open a new window with a Blazor component |
+| `OpenAsync(Type, ...)` | Open a new window with a component type |
+| `CloseAsync(handle)` | Close a child window |
+| `WindowOpened` | Event fired when any window is opened |
+| `WindowClosed` | Event fired when any window is closed |
+
+### Behavior Notes
+- **Child window ownership**: All child windows are owned by the main window, so they stack and minimize together following standard WPF behavior.
+- **Shutdown policy**: Closing the main window closes the entire application and all child windows. Closing a child window only removes that window.
+- **DI scoping**: Each window runs its own `BlazorWebView` which creates an independent Blazor DI scope. Scoped services are per-window; singleton services are shared across all windows.
+- **Thread safety**: `IWindowManager` is safe to call from any thread. All WPF operations are automatically marshaled to the UI thread.
+- **Component parameters**: You can pass parameters to child window root components via the `parameters` argument on `OpenAsync` or the `Parameters` property on `<DesktopWindow>`.
+
+### Full Example
+The `BlazorDesktop.Sample` project includes a working multi-window demo. Navigate to the **Multi-Window** page to try both APIs. The sample shows:
+
+- Opening child windows with the service-based API via `IWindowManager.OpenAsync<T>()`
+- Toggling child windows with the component-based API via `<DesktopWindow>`
+- Each child window running its own independent counter
+- Tracking the number of open windows in real time
 
 ## Issues
 Under the hood, Blazor Desktop uses WebView2 which has limitations right now with composition. Due to this, if you disable the window border through the `Window.UseFrame(false)` API, the top edge of the window is unusable as a resizing zone for the window. However all the other corners and edges work.

--- a/src/BlazorDesktop.Sample/Components/Layout/NavMenu.razor
+++ b/src/BlazorDesktop.Sample/Components/Layout/NavMenu.razor
@@ -29,5 +29,11 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="multiwindow">
+                <span class="bi bi-window-nav-menu" aria-hidden="true"></span> Multi-Window
+            </NavLink>
+        </div>
     </nav>
 </div>

--- a/src/BlazorDesktop.Sample/Components/Layout/NavMenu.razor.css
+++ b/src/BlazorDesktop.Sample/Components/Layout/NavMenu.razor.css
@@ -50,6 +50,10 @@
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-list-nested' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.5 11.5A.5.5 0 0 1 5 11h10a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5zm-2-4A.5.5 0 0 1 3 7h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm-2-4A.5.5 0 0 1 1 3h10a.5.5 0 0 1 0 1H1a.5.5 0 0 1-.5-.5z'/%3E%3C/svg%3E");
 }
 
+.bi-window-nav-menu {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' viewBox='0 0 16 16'%3E%3Cpath d='M14 2a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zM2 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2z'/%3E%3Cpath d='M3 5.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5M11 2a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1V2z'/%3E%3C/svg%3E");
+}
+
 .nav-item {
     font-size: 0.9rem;
     padding-bottom: 0.5rem;

--- a/src/BlazorDesktop.Sample/Components/Pages/ChildWindowContent.razor
+++ b/src/BlazorDesktop.Sample/Components/Pages/ChildWindowContent.razor
@@ -1,0 +1,30 @@
+@* Licensed to the .NET Extension Contributors under one or more agreements. *@
+@* The .NET Extension Contributors licenses this file to you under the MIT license. *@
+@* See the LICENSE file in the project root for more information. *@
+
+<div style="padding: 2rem; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+    <h2>Child Window</h2>
+    <p>This is running in its own window with an independent Blazor component tree.</p>
+
+    <hr />
+
+    <h4>Counter</h4>
+    <p role="status">Current count: @currentCount</p>
+    <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+    <hr />
+
+    <p style="color: #888; font-size: 0.85rem; margin-top: 1rem;">
+        Window opened at @openedAt.ToString("HH:mm:ss")
+    </p>
+</div>
+
+@code {
+    private int currentCount = 0;
+    private DateTime openedAt = DateTime.Now;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}

--- a/src/BlazorDesktop.Sample/Components/Pages/MultiWindow.razor
+++ b/src/BlazorDesktop.Sample/Components/Pages/MultiWindow.razor
@@ -1,0 +1,59 @@
+@* Licensed to the .NET Extension Contributors under one or more agreements. *@
+@* The .NET Extension Contributors licenses this file to you under the MIT license. *@
+@* See the LICENSE file in the project root for more information. *@
+
+@page "/multiwindow"
+@using BlazorDesktop.Components
+@using BlazorDesktop.Services
+@inject IWindowManager WindowManager
+
+<h1>Multi-Window Demo</h1>
+
+<p>This page demonstrates opening child windows using both the service-based and component-based APIs.</p>
+
+<h3>Service-based API</h3>
+<p>Open windows programmatically via <code>IWindowManager</code>.</p>
+<button class="btn btn-primary" @onclick="OpenServiceWindow">Open Window (Service)</button>
+
+<hr />
+
+<h3>Component-based API</h3>
+<p>Toggle a window declaratively with the <code>&lt;DesktopWindow&gt;</code> component.</p>
+<button class="btn btn-success" @onclick="ToggleComponentWindow">
+    @(_showComponentWindow ? "Close Window (Component)" : "Open Window (Component)")
+</button>
+
+@if (_showComponentWindow)
+{
+    <DesktopWindow ComponentType="typeof(ChildWindowContent)"
+                   Title="Component Window" Width="500" Height="350"
+                   OnClosed="@(() => { _showComponentWindow = false; InvokeAsync(StateHasChanged); })" />
+}
+
+<hr />
+
+<h3>Open Windows</h3>
+<p>Currently tracking <strong>@WindowManager.Windows.Count</strong> window(s).</p>
+
+@code {
+    private bool _showComponentWindow;
+
+    private async Task OpenServiceWindow()
+    {
+        var handle = await WindowManager.OpenAsync<ChildWindowContent>(options =>
+        {
+            options.Title = "Service Window";
+            options.Width = 500;
+            options.Height = 350;
+        });
+
+        handle.Closed += (_, _) => InvokeAsync(StateHasChanged);
+
+        StateHasChanged();
+    }
+
+    private void ToggleComponentWindow()
+    {
+        _showComponentWindow = !_showComponentWindow;
+    }
+}

--- a/src/BlazorDesktop/Components/DesktopWindow.cs
+++ b/src/BlazorDesktop/Components/DesktopWindow.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Extension Contributors under one or more agreements.
+// The .NET Extension Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BlazorDesktop.Hosting;
+using BlazorDesktop.Services;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorDesktop.Components;
+
+/// <summary>
+/// A Blazor component that manages a desktop window declaratively.
+/// When rendered, opens a new window. When removed from the render tree, closes it.
+/// </summary>
+public sealed class DesktopWindow : ComponentBase, IAsyncDisposable
+{
+    [Inject]
+    private IWindowManager WindowManager { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the root component type for the window.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public Type ComponentType { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the window title.
+    /// </summary>
+    [Parameter]
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the window width.
+    /// </summary>
+    [Parameter]
+    public int? Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the window height.
+    /// </summary>
+    [Parameter]
+    public int? Height { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum window width.
+    /// </summary>
+    [Parameter]
+    public int? MinWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum window height.
+    /// </summary>
+    [Parameter]
+    public int? MinHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum window width.
+    /// </summary>
+    [Parameter]
+    public int? MaxWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum window height.
+    /// </summary>
+    [Parameter]
+    public int? MaxHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the window uses a standard frame.
+    /// </summary>
+    [Parameter]
+    public bool? Frame { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the window is resizable.
+    /// </summary>
+    [Parameter]
+    public bool? Resizable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the window icon path.
+    /// </summary>
+    [Parameter]
+    public string? Icon { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional parameters to pass to the root component.
+    /// </summary>
+    [Parameter]
+    public IDictionary<string, object?>? Parameters { get; set; }
+
+    /// <summary>
+    /// Called when the window is closed (either programmatically or by the user).
+    /// </summary>
+    [Parameter]
+    public EventCallback OnClosed { get; set; }
+
+    private DesktopWindowHandle? _handle;
+    private bool _disposed;
+
+    /// <inheritdoc/>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        _handle = await WindowManager.OpenAsync(ComponentType, options =>
+        {
+            options.Title = Title;
+            options.Width = Width;
+            options.Height = Height;
+            options.MinWidth = MinWidth;
+            options.MinHeight = MinHeight;
+            options.MaxWidth = MaxWidth;
+            options.MaxHeight = MaxHeight;
+            options.Frame = Frame;
+            options.Resizable = Resizable;
+            options.Icon = Icon;
+        }, Parameters);
+
+        _handle.Closed += OnHandleClosed;
+    }
+
+    private async void OnHandleClosed(object? sender, EventArgs e)
+    {
+        if (_handle is not null)
+        {
+            _handle.Closed -= OnHandleClosed;
+        }
+
+        await InvokeAsync(async () =>
+        {
+            if (OnClosed.HasDelegate)
+            {
+                await OnClosed.InvokeAsync();
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        if (_handle is not null)
+        {
+            _handle.Closed -= OnHandleClosed;
+
+            if (_handle.NativeWindow is not null)
+            {
+                await WindowManager.CloseAsync(_handle);
+            }
+
+            _handle = null;
+        }
+    }
+}

--- a/src/BlazorDesktop/Hosting/BlazorDesktopHostBuilder.cs
+++ b/src/BlazorDesktop/Hosting/BlazorDesktopHostBuilder.cs
@@ -4,7 +4,6 @@
 
 using System.Windows;
 using BlazorDesktop.Services;
-using BlazorDesktop.Wpf;
 
 namespace BlazorDesktop.Hosting;
 
@@ -123,7 +122,7 @@ public sealed class BlazorDesktopHostBuilder
         Services.AddWpfBlazorWebView();
         Services.AddSingleton<WebViewInstaller>();
         Services.AddSingleton<Application>();
-        Services.AddSingleton<BlazorDesktopWindow>();
+        Services.AddSingleton<IWindowManager, WindowManager>();
         Services.AddHostedService<BlazorDesktopService>();
     }
 

--- a/src/BlazorDesktop/Hosting/DesktopWindowHandle.cs
+++ b/src/BlazorDesktop/Hosting/DesktopWindowHandle.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Extension Contributors under one or more agreements.
+// The .NET Extension Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BlazorDesktop.Wpf;
+
+namespace BlazorDesktop.Hosting;
+
+/// <summary>
+/// A lightweight, thread-safe handle to a managed desktop window.
+/// </summary>
+public sealed class DesktopWindowHandle
+{
+    /// <summary>
+    /// Gets the unique identifier for this window.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Gets whether this is the main application window.
+    /// </summary>
+    public bool IsMainWindow { get; }
+
+    /// <summary>
+    /// Gets the native WPF window. Internal use only.
+    /// </summary>
+    internal BlazorDesktopWindow? NativeWindow { get; set; }
+
+    /// <summary>
+    /// Occurs when the window is closed.
+    /// </summary>
+    public event EventHandler? Closed;
+
+    /// <summary>
+    /// Creates a new <see cref="DesktopWindowHandle"/>.
+    /// </summary>
+    /// <param name="id">The unique window identifier.</param>
+    /// <param name="isMainWindow">Whether this is the main window.</param>
+    internal DesktopWindowHandle(string id, bool isMainWindow)
+    {
+        Id = id;
+        IsMainWindow = isMainWindow;
+    }
+
+    /// <summary>
+    /// Raises the <see cref="Closed"/> event.
+    /// </summary>
+    internal void OnClosed()
+    {
+        Closed?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/BlazorDesktop/Hosting/WindowOptions.cs
+++ b/src/BlazorDesktop/Hosting/WindowOptions.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Extension Contributors under one or more agreements.
+// The .NET Extension Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace BlazorDesktop.Hosting;
+
+/// <summary>
+/// Per-window configuration options.
+/// </summary>
+public class WindowOptions
+{
+    /// <summary>
+    /// Gets or sets the window title.
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the window height.
+    /// </summary>
+    public int? Height { get; set; }
+
+    /// <summary>
+    /// Gets or sets the window width.
+    /// </summary>
+    public int? Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum window height.
+    /// </summary>
+    public int? MinHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum window width.
+    /// </summary>
+    public int? MinWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum window height.
+    /// </summary>
+    public int? MaxHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum window width.
+    /// </summary>
+    public int? MaxWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the window uses a standard frame.
+    /// </summary>
+    public bool? Frame { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the window is resizable.
+    /// </summary>
+    public bool? Resizable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the window icon path.
+    /// </summary>
+    public string? Icon { get; set; }
+
+    /// <summary>
+    /// Creates a <see cref="WindowOptions"/> from the existing <see cref="IConfiguration"/> keys.
+    /// </summary>
+    /// <param name="config">The configuration.</param>
+    /// <returns>A populated <see cref="WindowOptions"/>.</returns>
+    public static WindowOptions FromConfiguration(IConfiguration config)
+    {
+        return new WindowOptions
+        {
+            Title = config.GetValue<string?>(WindowDefaults.Title),
+            Height = config.GetValue<int?>(WindowDefaults.Height),
+            Width = config.GetValue<int?>(WindowDefaults.Width),
+            MinHeight = config.GetValue<int?>(WindowDefaults.MinHeight),
+            MinWidth = config.GetValue<int?>(WindowDefaults.MinWidth),
+            MaxHeight = config.GetValue<int?>(WindowDefaults.MaxHeight),
+            MaxWidth = config.GetValue<int?>(WindowDefaults.MaxWidth),
+            Frame = config.GetValue<bool?>(WindowDefaults.Frame),
+            Resizable = config.GetValue<bool?>(WindowDefaults.Resizable),
+            Icon = config.GetValue<string?>(WindowDefaults.Icon)
+        };
+    }
+}

--- a/src/BlazorDesktop/Services/BlazorDesktopService.cs
+++ b/src/BlazorDesktop/Services/BlazorDesktopService.cs
@@ -2,6 +2,7 @@
 // The .NET Extension Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using BlazorDesktop.Hosting;
 using BlazorDesktop.Wpf;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -69,7 +70,15 @@ public partial class BlazorDesktopService : IHostedService, IDisposable
     private void ApplicationThread()
     {
         var app = _services.GetRequiredService<Application>();
-        var mainWindow = _services.GetRequiredService<BlazorDesktopWindow>();
+        var config = _services.GetRequiredService<IConfiguration>();
+        var environment = _services.GetRequiredService<IWebHostEnvironment>();
+        var rootComponents = _services.GetRequiredService<RootComponentMappingCollection>();
+        var options = WindowOptions.FromConfiguration(config);
+
+        var mainWindow = new BlazorDesktopWindow(_services, environment, options, rootComponents);
+
+        var windowManager = (WindowManager)_services.GetRequiredService<IWindowManager>();
+        windowManager.RegisterMainWindow(mainWindow, app.Dispatcher);
 
         app.Startup += OnApplicationStartup;
         app.Exit += OnApplicationExit;

--- a/src/BlazorDesktop/Services/IWindowManager.cs
+++ b/src/BlazorDesktop/Services/IWindowManager.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Extension Contributors under one or more agreements.
+// The .NET Extension Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BlazorDesktop.Hosting;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorDesktop.Services;
+
+/// <summary>
+/// Manages multiple desktop windows. Safe to call from any thread.
+/// </summary>
+public interface IWindowManager
+{
+    /// <summary>
+    /// Gets the main application window handle.
+    /// </summary>
+    DesktopWindowHandle MainWindow { get; }
+
+    /// <summary>
+    /// Gets all currently open window handles.
+    /// </summary>
+    IReadOnlyList<DesktopWindowHandle> Windows { get; }
+
+    /// <summary>
+    /// Opens a new window hosting the specified component.
+    /// </summary>
+    /// <typeparam name="TComponent">The root Blazor component for the window.</typeparam>
+    /// <param name="configure">Optional configuration for window options.</param>
+    /// <param name="parameters">Optional parameters to pass to the root component.</param>
+    /// <returns>A handle to the opened window.</returns>
+    Task<DesktopWindowHandle> OpenAsync<TComponent>(Action<WindowOptions>? configure = null, IDictionary<string, object?>? parameters = null) where TComponent : IComponent;
+
+    /// <summary>
+    /// Opens a new window hosting the specified component type.
+    /// </summary>
+    /// <param name="componentType">The root Blazor component type for the window.</param>
+    /// <param name="configure">Optional configuration for window options.</param>
+    /// <param name="parameters">Optional parameters to pass to the root component.</param>
+    /// <returns>A handle to the opened window.</returns>
+    Task<DesktopWindowHandle> OpenAsync(Type componentType, Action<WindowOptions>? configure = null, IDictionary<string, object?>? parameters = null);
+
+    /// <summary>
+    /// Closes the specified window.
+    /// </summary>
+    /// <param name="handle">The window handle to close.</param>
+    Task CloseAsync(DesktopWindowHandle handle);
+
+    /// <summary>
+    /// Occurs when a window is opened.
+    /// </summary>
+    event EventHandler<DesktopWindowHandle>? WindowOpened;
+
+    /// <summary>
+    /// Occurs when a window is closed.
+    /// </summary>
+    event EventHandler<DesktopWindowHandle>? WindowClosed;
+}

--- a/src/BlazorDesktop/Services/WindowManager.cs
+++ b/src/BlazorDesktop/Services/WindowManager.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Extension Contributors under one or more agreements.
+// The .NET Extension Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using BlazorDesktop.Hosting;
+using BlazorDesktop.Wpf;
+using Microsoft.AspNetCore.Components;
+using WpfDispatcher = System.Windows.Threading.Dispatcher;
+
+namespace BlazorDesktop.Services;
+
+/// <summary>
+/// Internal implementation of <see cref="IWindowManager"/>.
+/// </summary>
+internal sealed class WindowManager : IWindowManager
+{
+    private readonly ConcurrentDictionary<string, DesktopWindowHandle> _windows = new();
+    private readonly IServiceProvider _services;
+    private readonly IWebHostEnvironment _environment;
+    private DesktopWindowHandle? _mainWindow;
+    private WpfDispatcher? _dispatcher;
+
+    /// <inheritdoc/>
+    public DesktopWindowHandle MainWindow => _mainWindow ?? throw new InvalidOperationException("The main window has not been registered yet.");
+
+    /// <inheritdoc/>
+    public IReadOnlyList<DesktopWindowHandle> Windows => _windows.Values.ToList().AsReadOnly();
+
+    /// <inheritdoc/>
+    public event EventHandler<DesktopWindowHandle>? WindowOpened;
+
+    /// <inheritdoc/>
+    public event EventHandler<DesktopWindowHandle>? WindowClosed;
+
+    public WindowManager(IServiceProvider services, IWebHostEnvironment environment)
+    {
+        _services = services;
+        _environment = environment;
+    }
+
+    /// <inheritdoc/>
+    public Task<DesktopWindowHandle> OpenAsync<TComponent>(Action<WindowOptions>? configure = null, IDictionary<string, object?>? parameters = null) where TComponent : IComponent
+    {
+        return OpenAsync(typeof(TComponent), configure, parameters);
+    }
+
+    /// <inheritdoc/>
+    public async Task<DesktopWindowHandle> OpenAsync(Type componentType, Action<WindowOptions>? configure = null, IDictionary<string, object?>? parameters = null)
+    {
+        ArgumentNullException.ThrowIfNull(componentType);
+
+        if (!typeof(IComponent).IsAssignableFrom(componentType))
+        {
+            throw new ArgumentException($"The type '{componentType.Name}' must implement {nameof(IComponent)} to be used as a root component.", nameof(componentType));
+        }
+
+        var dispatcher = _dispatcher ?? throw new InvalidOperationException("The WPF dispatcher has not been set. Ensure the main window is registered first.");
+
+        var options = new WindowOptions();
+        configure?.Invoke(options);
+
+        var handle = new DesktopWindowHandle(Guid.NewGuid().ToString("N"), isMainWindow: false);
+
+        var rootComponents = new RootComponentMappingCollection();
+        if (parameters is not null)
+        {
+            rootComponents.Add(componentType, "#app", ParameterView.FromDictionary(parameters));
+        }
+        else
+        {
+            rootComponents.Add(componentType, "#app");
+        }
+
+        await dispatcher.InvokeAsync(() =>
+        {
+            var window = new BlazorDesktopWindow(_services, _environment, options, rootComponents);
+
+            if (_mainWindow?.NativeWindow is not null)
+            {
+                window.Owner = _mainWindow.NativeWindow;
+            }
+
+            handle.NativeWindow = window;
+
+            window.Closed += (_, _) => OnChildWindowClosed(handle);
+
+            window.Show();
+        });
+
+        _windows.TryAdd(handle.Id, handle);
+        WindowOpened?.Invoke(this, handle);
+
+        return handle;
+    }
+
+    /// <inheritdoc/>
+    public async Task CloseAsync(DesktopWindowHandle handle)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+
+        if (handle.IsMainWindow)
+        {
+            throw new InvalidOperationException("The main window cannot be closed via IWindowManager. Use application shutdown instead.");
+        }
+
+        var dispatcher = _dispatcher ?? throw new InvalidOperationException("The WPF dispatcher has not been set.");
+
+        await dispatcher.InvokeAsync(() =>
+        {
+            handle.NativeWindow?.Close();
+        });
+    }
+
+    /// <summary>
+    /// Registers the main window and stores the WPF dispatcher. Called by <see cref="BlazorDesktopService"/>.
+    /// </summary>
+    internal void RegisterMainWindow(BlazorDesktopWindow window, WpfDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher;
+
+        var handle = new DesktopWindowHandle("main", isMainWindow: true)
+        {
+            NativeWindow = window
+        };
+
+        _mainWindow = handle;
+        _windows.TryAdd(handle.Id, handle);
+    }
+
+    private void OnChildWindowClosed(DesktopWindowHandle handle)
+    {
+        _windows.TryRemove(handle.Id, out _);
+        handle.NativeWindow = null;
+        handle.OnClosed();
+        WindowClosed?.Invoke(this, handle);
+    }
+}

--- a/src/BlazorDesktop/Wpf/BlazorDesktopWindow.cs
+++ b/src/BlazorDesktop/Wpf/BlazorDesktopWindow.cs
@@ -45,8 +45,9 @@ public partial class BlazorDesktopWindow : Window
 
     private WindowState _fullscreenStoredState = WindowState.Normal;
     private readonly IServiceProvider _services;
-    private readonly IConfiguration _config;
     private readonly IWebHostEnvironment _environment;
+    private readonly WindowOptions _options;
+    private readonly RootComponentMappingCollection _rootComponents;
     private readonly UISettings _uiSettings;
     private readonly double[] _zoomSizes =
         [5, 4, 3, 2.5, 2, 1.75, 1.5, 1.25, 1.1, 1, 0.9, 0.8, 0.75, 0.66, 0.5, 0.33, 0.25];
@@ -67,18 +68,31 @@ window.addEventListener('DOMContentLoaded', () => {
 ";
 
     /// <summary>
-    /// Creates a <see cref="BlazorDesktopWindow"/> instance.
+    /// Creates a <see cref="BlazorDesktopWindow"/> instance from configuration.
     /// </summary>
     /// <param name="services">The services.</param>
     /// <param name="config">The configuration.</param>
     /// <param name="environment">The hosting environment.</param>
     public BlazorDesktopWindow(IServiceProvider services, IConfiguration config, IWebHostEnvironment environment)
+        : this(services, environment, WindowOptions.FromConfiguration(config), services.GetRequiredService<RootComponentMappingCollection>())
+    {
+    }
+
+    /// <summary>
+    /// Creates a <see cref="BlazorDesktopWindow"/> instance with explicit options and root components.
+    /// </summary>
+    /// <param name="services">The services.</param>
+    /// <param name="environment">The hosting environment.</param>
+    /// <param name="options">The window options.</param>
+    /// <param name="rootComponents">The root component mappings.</param>
+    internal BlazorDesktopWindow(IServiceProvider services, IWebHostEnvironment environment, WindowOptions options, RootComponentMappingCollection rootComponents)
     {
         WebView = new BlazorWebView();
         WebViewBorder = new Border();
         _services = services;
-        _config = config;
         _environment = environment;
+        _options = options;
+        _rootComponents = rootComponents;
         _uiSettings = new UISettings();
 
         InitializeWindow();
@@ -92,12 +106,14 @@ window.addEventListener('DOMContentLoaded', () => {
     /// </summary>
     public void ToggleFullScreen()
     {
+        var useFrame = _options.Frame ?? true;
+
         if (WindowStyle == WindowStyle.SingleBorderWindow)
         {
             IsFullscreen = true;
             _fullscreenStoredState = WindowState;
 
-            UseFrame(_config.GetValue<bool?>(WindowDefaults.Frame) ?? true);
+            UseFrame(useFrame);
             WindowStyle = WindowStyle.None;
 
             if (WindowState == WindowState.Maximized)
@@ -113,7 +129,7 @@ window.addEventListener('DOMContentLoaded', () => {
         {
             IsFullscreen = false;
 
-            UseFrame(_config.GetValue<bool?>(WindowDefaults.Frame) ?? true);
+            UseFrame(useFrame);
             WindowStyle = WindowStyle.SingleBorderWindow;
             WindowState = _fullscreenStoredState;
 
@@ -171,14 +187,14 @@ window.addEventListener('DOMContentLoaded', () => {
 
     private void InitializeWindow()
     {
-        var height = _config.GetValue<int?>(WindowDefaults.Height) ?? 768;
-        var width = _config.GetValue<int?>(WindowDefaults.Width) ?? 1366;
-        var minHeight = _config.GetValue<int?>(WindowDefaults.MinHeight) ?? 0;
-        var minWidth = _config.GetValue<int?>(WindowDefaults.MinWidth) ?? 0;
-        var maxHeight = _config.GetValue<int?>(WindowDefaults.MaxHeight) ?? double.PositiveInfinity;
-        var maxWidth = _config.GetValue<int?>(WindowDefaults.MaxWidth) ?? double.PositiveInfinity;
+        var height = _options.Height ?? 768;
+        var width = _options.Width ?? 1366;
+        var minHeight = _options.MinHeight ?? 0;
+        var minWidth = _options.MinWidth ?? 0;
+        var maxHeight = (double?)_options.MaxHeight ?? double.PositiveInfinity;
+        var maxWidth = (double?)_options.MaxWidth ?? double.PositiveInfinity;
 
-        var useFrame = _config.GetValue<bool?>(WindowDefaults.Frame) ?? true;
+        var useFrame = _options.Frame ?? true;
 
         if (useFrame)
         {
@@ -232,7 +248,7 @@ window.addEventListener('DOMContentLoaded', () => {
         }
 
         Name = "BlazorDesktopWindow";
-        Title = _config.GetValue<string?>(WindowDefaults.Title) ?? _environment.ApplicationName;
+        Title = _options.Title ?? _environment.ApplicationName;
         Height = height;
         Width = width;
         MinHeight = minHeight;
@@ -240,8 +256,8 @@ window.addEventListener('DOMContentLoaded', () => {
         MaxHeight = maxHeight;
         MaxWidth = maxWidth;
         UseFrame(useFrame);
-        ResizeMode = (_config.GetValue<bool?>(WindowDefaults.Resizable) ?? true) ? ResizeMode.CanResize : ResizeMode.NoResize;
-        UseIcon(_config.GetValue<string?>(WindowDefaults.Icon) ?? string.Empty);
+        ResizeMode = (_options.Resizable ?? true) ? ResizeMode.CanResize : ResizeMode.NoResize;
+        UseIcon(_options.Icon ?? string.Empty);
         Content = WebViewBorder;
         StateChanged += WindowStateChanged;
         KeyDown += WindowKeyDown;
@@ -261,7 +277,7 @@ window.addEventListener('DOMContentLoaded', () => {
         WebView.HostPage = Path.Combine(_environment.WebRootPath, "index.html");
         WebView.Services = _services;
 
-        foreach (var rootComponent in _services.GetRequiredService<RootComponentMappingCollection>())
+        foreach (var rootComponent in _rootComponents)
         {
             WebView.RootComponents.Add(new()
             {
@@ -305,7 +321,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     private void UpdateWebViewBorderThickness()
     {
-        var useFrame = _config.GetValue<bool?>(WindowDefaults.Frame) ?? true;
+        var useFrame = _options.Frame ?? true;
 
         WebViewBorder.BorderThickness = new Thickness(20, 20, 20, 20);
 


### PR DESCRIPTION
# Multi Window Support
 
## Summary

  - Add IWindowManager service for opening and managing multiple desktop windows, each with an independent Blazor component tree
  - Add <DesktopWindow> Razor component for declarative window management (open on render, close on dispose)
  - Refactor BlazorDesktopWindow to accept WindowOptions POCO instead of reading IConfiguration directly, enabling child windows with custom settings
  - Add multi-window demo page to BlazorDesktop.Sample showcasing both service-based and component-based APIs
  - Update README with multi-window documentation, API reference, and updated examples

  New files

  - Hosting/WindowOptions.cs - Per-window configuration POCO with FromConfiguration() factory
  - Hosting/DesktopWindowHandle.cs - Lightweight handle to a managed window (Id, IsMainWindow, Closed event)
  - Services/IWindowManager.cs - Public interface: OpenAsync<T>(), CloseAsync(), MainWindow, events
  - Services/WindowManager.cs - Internal implementation with ConcurrentDictionary tracking, WPF Dispatcher marshaling
  - Components/DesktopWindow.cs - Blazor component wrapping IWindowManager for declarative usage

  Modified files

  - Wpf/BlazorDesktopWindow.cs - Added internal constructor accepting WindowOptions + RootComponentMappingCollection; replaced all IConfiguration reads with _options field
  - Hosting/BlazorDesktopHostBuilder.cs - Replaced BlazorDesktopWindow singleton with IWindowManager/WindowManager singleton
  - Services/BlazorDesktopService.cs - Creates BlazorDesktopWindow manually on STA thread; registers with WindowManager

  Breaking change

  BlazorDesktopWindow is no longer registered in the DI container. Code that injected it directly must use IWindowManager.MainWindow.NativeWindow instead.

  ## Test plan

  - dotnet build BlazorDesktop.sln succeeds with 0 warnings/errors
  - Run BlazorDesktop.Sample, verify main window works identically to before
  - Navigate to Multi-Window page, click "Open Window (Service)" - child window opens with correct title/size and independent counter
  - Click "Open Window (Component)" - toggle opens/closes a declarative child window
  - Close a child window via X button - Closed event fires, window count updates, main app stays open
  - Close main window - all child windows close and app exits